### PR TITLE
Use protocol version v0.2.0-alpha.1

### DIFF
--- a/contracts/contracts/Base.sol
+++ b/contracts/contracts/Base.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.18;
 
 import {ISafeProtocolPlugin} from "@safe-global/safe-core-protocol/contracts/interfaces/Integrations.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 enum MetadataProviderType {
     IPFS,
@@ -55,6 +56,10 @@ abstract contract BasePlugin is ISafeProtocolPlugin {
         version = metadata.version;
         requiresRootAccess = metadata.requiresRootAccess;
         metadataHash = keccak256(metadata.encode());
+    }
+
+    function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
+        return interfaceId == type(ISafeProtocolPlugin).interfaceId || interfaceId == type(IERC165).interfaceId;
     }
 }
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -32,7 +32,7 @@
     "@nomicfoundation/hardhat-verify": "^1.0.0",
     "@openzeppelin/contracts": "^4.9.1",
     "@safe-global/mock-contract": "^4.0.0",
-    "@safe-global/safe-core-protocol": "^0.1.0-alpha.4",
+    "@safe-global/safe-core-protocol": "0.2.0-alpha.1",
     "@safe-global/safe-singleton-factory": "^1.0.14",
     "@typechain/ethers-v6": "^0.4.0",
     "@typechain/hardhat": "^8.0.0",

--- a/contracts/yarn.lock
+++ b/contracts/yarn.lock
@@ -800,10 +800,10 @@
   resolved "https://registry.yarnpkg.com/@safe-global/mock-contract/-/mock-contract-4.0.0.tgz#8e1e17e93af5d4b343a6bb6cef8c1f513cb7a92e"
   integrity sha512-6ijStTgQI6JzYe8Nsc4j1VW4XQ89qCl7ZkRGxwwlxnaOMDYzVekwPACbg2kDDzhtJ4p8vSvE6ZroxSkvP7610A==
 
-"@safe-global/safe-core-protocol@^0.1.0-alpha.4":
-  version "0.1.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-core-protocol/-/safe-core-protocol-0.1.0-alpha.4.tgz#a00622198458551c8cf4f339872939be5de0d233"
-  integrity sha512-d+2qnyqf3WdERlxwxZAxxTk0N0MYfr+ICqIem78rDYKlRYxbnM7AKlXXSiYJbPNADZ49cakPmib59Rs0IK93Kg==
+"@safe-global/safe-core-protocol@0.2.0-alpha.1":
+  version "0.2.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-core-protocol/-/safe-core-protocol-0.2.0-alpha.1.tgz#9cf37979851fde3adb3f77889c49ae408def0305"
+  integrity sha512-A12SNpMKxd3/QgJ2qZKNf8XhUIVsJFDBqJ3bcX5hUvnks1lK0fBVupWFasQuWsPZiGx7RBhtFqTmKyPYzVYJhQ==
 
 "@safe-global/safe-singleton-factory@^1.0.14":
   version "1.0.14"


### PR DESCRIPTION
Fixes #24 

Changes in PR:
- Use package `@safe-global/safe-core-protocol@v0.2.0-alpha.1`
- `BasePlugin` implements IERC165 interface