### PR TITLE
fix: typo on `Home`

### DIFF
--- a/web/src/routes/home/Home.tsx
+++ b/web/src/routes/home/Home.tsx
@@ -7,10 +7,8 @@ function Home() {
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Safe&#123;Core&#125; Protocol Demo
-        </p>
-        <Link to="/plugins">Show availabe Plugins</Link>
+        <p>Safe&#123;Core&#125; Protocol Demo</p>
+        <Link to="/plugins">Show available Plugins</Link>
       </header>
     </div>
   );


### PR DESCRIPTION
This fixes a typo on the `Home` page: "availabe" => "available".